### PR TITLE
Update the SDK Version v28 -> v33

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": ["babel-preset-expo"],
-  "env": {
-    "development": {
-      "plugins": ["transform-react-jsx-source"]
-    }
-  }
-}

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "This project is really great.",
     "slug": "bootcamp-demo",
     "privacy": "public",
-    "sdkVersion": "28.0.0",
+    "sdkVersion": "33.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "dependencies": {
-    "expo": "^28.0.0",
-    "react": "16.3.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-28.0.0.tar.gz",
+    "expo": "^33.0.0",
+    "react": "16.8.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
     "react-navigation": "^2.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Expo clients do not support SDK Versions below `v31`, hence I upgraded the project to `v33`

Alongside that, there was an error due to `.babelrc` which was caused due to the upgradation as it needed the file `babel.config.js`

After the changes, the app was working fine and was running on both iOS & Android smoothly.